### PR TITLE
Add 2D support

### DIFF
--- a/src/HJBSolver.jl
+++ b/src/HJBSolver.jl
@@ -6,4 +6,6 @@ include("types.jl")
 
 include("solver.jl")
 
+include("solver2d.jl")
+
 end # module

--- a/src/solver2d.jl
+++ b/src/solver2d.jl
@@ -1,36 +1,78 @@
 # TODO: better names for the functions
 
-function updatecoeffs!{T<:Real}(coeff0, coeff1f, coeff1b, coeff2f, coeff2b, rhs, model, v, t::T, x,
-                                a1::Vector{T}, a1::Vector{T}, Δτ::T, Δx::Vector{T})
+function setIJV!{T<:Real}(I::Vector{Int},J::Vector{Int},V::Vector{T},
+                          Ival::Int,Jval::Int,Vval::T,counter::Int)
+    counter = counter+1
+    I[counter] = Ival
+    J[counter] = Jval
+    V[counter] = Vval
+
+    return counter
+end
+
+function updatecoeffs!{T<:Real}(I, J, V, rhs, model, v, t::T, x,
+                                a1::Vector{T}, a2::Vector{T}, Δτ::T, Δx::Vector{T})
     # Updates:
     # rhs    = value function at previous timestep + f at current timestep
-    # coeffn = values in linear system
-    # e.g. coeff0  is the coefficient in front of v at x_{i,j}
-    #      coeff1f is the coefficient in front of v at x_{i+1,j}
-    #      coeff2b is the coefficient in front of v at x_{i,j-1}
-
+    # I,J,V  = vectors for creating sparse system matrix (see ?sparse)
 
     # Input
     # model  = HJBOneDim object
     # v      = value function at previous timestep
     # t      = value of (forward) time
-    # x      = vector of x-values
+    # x      = tuple of vectors of x-values
     # a1     = policy-values on interior, element 1
     # a2     = policy-values on interior, element 2
     # Δτ     = time-step size
     # Δx     = spacial step length
-    taux = Δτ/Δx
-    htaux2 = 0.5*Δτ/Δx^2
+    taux = Δτ ./Δx
+    htaux2 = 0.5*Δτ ./ Δx.^2
+    K = [length(xi) for xi in x]
 
-    n = length(coeff0)
-    for j = 2:n-1
-        bval = model.b(t,x[j],a[j-1])
-        sval2 = model.σ(t,x[j],a[j-1])^2
-        coeff1[j] = -(sval2*htaux2 + max(bval,0.)*taux)
-        coeff2[j-1] = -(sval2*htaux2 - min(bval,0.)*taux)
-        coeff0[j] = 1.-coeff1[j]-coeff2[j-1]
-        rhs[j] = v[j] + Δτ*model.f(t,x[j],a[j-1])
+    counter = 0
+    # Dirichlet conditions for x_1 = {xmin, xmax}
+    for i = [1, K[1]], j = 1:K[2]
+        idxi = K[2]*(i-1) + j
+        xij = [x[1][i], x[2][j]])
+        counter = setIJV!(I,J,V,idxi,idxi,1.0,counter)
+        rhs[idxi] = model.Dbound(t, xij)
     end
+
+    # Dirichlet conditions for x_2 = {xmin, xmax}
+    for i = 2:K[1]-1, j = [1, K[2]]
+        idxi = K[2]*(i-1)+j
+        xij = [x[1][i], x[2][j]])
+        counter = setIJV!(I,J,V,idxi,idxi,1.0,counter)
+        rhs[idxi] = model.Dbound(t, xij)
+    end
+
+    # Interior coefficients
+    for i = 2:K[1]-1, j = 2:K[2]-1
+        idxi = K[2]*(i-1) + j
+        idxj1f = idxi + K[2]; idxj1b = idxi - K[2]
+        idxj2f = idxi + 1;    idxj2b = idxi - 1
+        xij = [x[1][i], x[2][j]]
+        aij = [a1[idxi], a2[idxi]]
+
+        bval = model.b(t,xij,aij)
+        sval2 = model.σ(t,xij,aij).^2
+        coeff1f = -(sval2[1]*htaux2[1] + max(bval[1],0.)*taux[1])
+        coeff1b = -(sval2[1]*htaux2[1] - min(bval[1],0.)*taux[1])
+        coeff2f = -(sval2[2]*htaux2[2] + max(bval[2],0.)*taux[2])
+        coeff2b = -(sval2[2]*htaux2[2] - min(bval[2],0.)*taux[2])
+        coeff0 = 1.0-(coeff1f+coeff1b + coeff2f+coeff2b)
+
+        # TODO: does it make a performance difference what order I put these in?
+        counter = setIJV!(I,J,V,idxi,idxi,coeff0, counter)
+        counter = setIJV!(I,J,V,idxi,idxj1f,coeff1f, counter)
+        counter = setIJV!(I,J,V,idxi,idxj1b,coeff1b, counter)
+        counter = setIJV!(I,J,V,idxi,idxj2f,coeff2f, counter)
+        counter = setIJV!(I,J,V,idxi,idxj2b,coeff2b, counter)
+
+        rhs[idxi] = v[idxi] + Δτ*model.f(t,xij,aij)
+    end
+
+    @assert counter == length(V)
 end
 
 function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector)
@@ -40,45 +82,49 @@ function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector)
     # (the gradient should be diagonal?)
     @assert size(pol1) == size(pol2)
 
-    K = [length(x[1]), length(x[2])]
+    K = [length(xi) for xi in x]
     idx = 1.0 ./ Δx
     hdx2 = 0.5 ./ Δx.^2
 
     function hamiltonian(a, i::Int, j::Int)
-        # Evaluate Hamiltonian with value a at (t,x_{i,j})
-        linindex = K[2]*(i-1) + j
-        idx1f = linindex + K[2]; idx1b = linindex - K[2]
-        idx2f = linindex + 1;    idx2b = linindex - 1
+        # Evaluate Hamiltonian with value a at (t,x_{i,j}), indices starting at 1
+        # coeffn = values in linear system
+        # e.g. coeff0  is the coefficient in front of v at x_{i,j}
+        #      coeff1f is the coefficient in front of v at x_{i+1,j}
+        #      coeff2b is the coefficient in front of v at x_{i,j-1}
+        idxi = K[2]*(i-1) + j
+        idxj1f = idxi + K[2]; idxj1b = idxi - K[2]
+        idxj2f = idxi + 1;    idxj2b = idxi - 1
 
         xij = [x[1][i], x[2][j]]
         bval = model.b(t,xij,a)
         sval2 = model.σ(t,xij,a).^2
-        coeff1f = sval2[1]*hdx2[1] + max(bval[1],0.)*idx[1]
-        coeff1b = sval2[1]*hdx2[1] - min(bval[1],0.)*idx[1]
-        coeff2f = sval2[2]*hdx2[2] + max(bval[2],0.)*idx[2]
-        coeff2b = sval2[2]*hdx2[2] - min(bval[2],0.)*idx[2]
-        coeff0 = -(coeff1f+coeff1b + coeff2f+coeff2b)
-        return (coeff0*v[linindex] + coeff1f*v[idx1f] + coeff1b*v[idx1b] +
-                coeff2f*v[idx2f] + coeff2b*v[idx2b] - model.f(t,xij,a))
+        coeff1f = sval2[1]*hdx2[1] + max(bval[1],0.)*idxj[1]
+        coeff1b = sval2[1]*hdx2[1] - min(bval[1],0.)*idxj[1]
+        coeff2f = sval2[2]*hdx2[2] + max(bval[2],0.)*idxj[2]
+        coeff2b = sval2[2]*hdx2[2] - min(bval[2],0.)*idxj[2]
+        return (coeff1f*(v[idxj1f]-v[idxi]) + coeff1b*(v[idxj1b]-v[idxi]) +
+                coeff2f*(v[idxj2f]-v[idxi]) + coeff2b*(v[idxj2b]-v[idxi]) -
+                model.f(t,xij,a))
     end
 
-    # TODO: redo pol with same size as v?
-    for i = 1:K[1]-2, j = 1:K[2]-2
-        linidx = K[2]*(i-1) + j
-        objective(a) = hamiltonian(a, i+1, j+1) # i+1,j+1 as the control only lives on the interior
+    # Only find control values at interior
+    for i = 2:K[1]-1, j = 2:K[2]-1
+        idxi = K[2]*(i-1) + j
+        objective(a) = hamiltonian(a, i, j)
         g!(x, out) = ForwardDiff.gradient!(out, objective, x)
         diffobj = DifferentiableFunction(objective, g!)
-        res = optimize(diffobj, [pol1[linidx], pol2[linidx]],
+        res = optimize(diffobj, [pol1[idxi], pol2[idxi]],
                        model.amin, model.amax, Fminbox(),
-                       optimizer=LBFGS)
+                       optimizer = LBFGS)
 
-        pol1[linidx], pol2[linidx] = res.minimum
+        pol1[idxi], pol2[idxi] = res.minimum
     end
 end
 
 function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
-                                     v, a1, a2, x::Tuple,
-                                     Δx, Δτ, ti::Int;
+                                     v, a1, a2, x::Tuple{Vector{T},Vector{T}},
+                                     Δx::Vector{T}, Δτ, ti::Int;
                                      tol = 1e-3,
                                      scale = 1.0,
                                      maxpolicyiter::Int = 10)
@@ -86,47 +132,34 @@ function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
     # an = policy function at previous time-step / initial guess for update
     tol = 1e-3
     scale = 1.0
-    maxpolicyiter = 10
     t = model.T - ti*Δτ
     n = length(v)
-    K = [length(x[1]), length(x[2])]
-    @assert length(a1) == n-2 && length(a2) == n-2
+    K = [length(xi) for xi in x]
+    @assert length(a1) == n && length(a2) == n
 
-    coeff0 = ones(v)   # v_i
-    coeff1 = zeros(n-1) # v_{i+1} # TODO: type stability
-    coeff2 = zeros(n-1) # v_{i-1} # TODO: type stability
+    # Elements in sparse system matrix (n\times n) size
+    interiornnz = 5*prod(K-2)
+    boundarynnz = 2*(sum(K)-2)
+    totnnz = interioirnnz + boundarynnz
+    I = zeros(totnnz); J = zeros(I); V = zeros(I)
+
     rhs = zeros(v)
     # TODO: add @inbounds
 
-    # Dirichlet conditions for x_2 = {xmin, xmax}
-    for i = 1:K[1]
-        # x_2 = xmin
-        rhs[K[2]*(i-1)+1] = model.Dbound(t, [x[1][i], x[2][1]])
-        # x_2 = xmax
-        rhs[K[2]*i] = model.Dbound(t, [x[1][i], x[2][K[2]]])
-    end
-    # Dirichlet conditions for x_1 = {xmin, xmax}
-    for i = 1:K[2]
-        # x_1 = xmin
-        rhs[i] = model.Dbound(t, [x[1][1], x[2][i]])
-        # x_1 = xmax
-        rhs[K[2]*(K[1]-1)+i] = model.Dbound(t, [x[1][K[1]], x[2][i]])
-    end
-
-    updatecoeffs!(coeff0, coeff1, coeff2, rhs, model, v, t, x, a1, a2, Δτ, Δx)
-    Mat = spdiagm((coeff2, coeff0, coeff1), -1:1, n, n)
+    updatecoeffs!(I,J,V, rhs, model, v, t, x, a1, a2, Δτ, Δx)
+    Mat = sparse(I,J,V,n,n,(x,y)->Base.error("Overlap"))
     vnew = Mat\rhs
 
-    pol1 = copy(a1) # TODO: just update a instead?
+    pol1 = copy(a1)
     pol2 = copy(a2)
     updatepol!(pol1, pol2, vnew, model, t, x, Δx)
 
     for k in 1:maxpolicyiter
-        updatecoeffs!(coeff0, coeff1, coeff2, rhs, model, v, t, x, pol, Δτ, Δx)
+        updatecoeffs!(I,J,V, rhs, model, v, t, x, pol1, pol2, Δτ, Δx)
 
-        Mat = spdiagm((coeff2, coeff0, coeff1), -1:1, n, n)
+        Mat = sparse(I,J,V,n,n,(x,y)->Base.error("Overlap"))
 
-        # TODO: Use Krylov solver for high-dimensional PDEs
+        # TODO: Use Krylov solver for high-dimensional PDEs?
         vold = vnew
         vnew = Mat\rhs
         updatepol!(pol1, pol2, vnew, model, t, x, Δx)
@@ -140,20 +173,20 @@ function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
     return vnew, pol1, pol2
 end
 
-function timeloopiteration(model::HJBTwoDimDim, K::Vector{Int}, N::Int,
-                           Δτ, vinit, x, Δx)
+function timeloopiteration(model::HJBTwoDim, K::Vector{Int}, N::Int,
+                           Δτ, vinit, x::Tuple, Δx::Vector)
     # Pass v and pol by reference?
     v = zeros(length(vinit), N+1)
-    # No policy at t = T or at x-boundaries
-    pol1 = zeros(prod(K-1), N)
-    pol2 = zeros(prod(K-1), N)
+    # No policy at t = T
+    pol1 = zeros(prod(K), N)
+    pol2 = zeros(prod(K), N)
     pol = (pol1, pol2)
 
     @inbounds v[:,1] = vinit # We use forward time t instead of backward time τ
 
     # initial guess for control
-    pol1init = 0.5*(model.amax[1]-model.amin[1])*ones(prod(K-1))
-    pol2init = 0.5*(model.amax[2]-model.amin[2])*ones(prod(K-1))
+    pol1init = 0.5*(model.amax[1]-model.amin[1])*ones(prod(K))
+    pol2init = 0.5*(model.amax[2]-model.amin[2])*ones(prod(K))
     @inbounds v[:,2], pol1[:,1], pol2[:,1] = policynewtonupdate(model, v[:,1], pol1init, pol2init,
                                                                 x, Δx, Δτ, 1)
 
@@ -169,23 +202,20 @@ function timeloopiteration(model::HJBTwoDimDim, K::Vector{Int}, N::Int,
 end
 
 function solveiteration{T1<:Real}(model::HJBTwoDim{T1}, K::Vector{Int}, N::Int)
-    # K+1 = number of points in each direction of the space domain
+    # K   = number of points in each direction of the space domain
     # N+1 = number of points in time domain
-    x1 = linspace(model.xmin[1], model.xmax[1], K[1]+1)
-    x2 = linspace(model.xmin[2], model.xmax[2], K[2]+1)
+    x1 = linspace(model.xmin[1], model.xmax[1], K[1])
+    x2 = linspace(model.xmin[2], model.xmax[2], K[2])
     x = (collect(x1), collect(x2))
-    Δx = (model.xmax-model.xmin)./K # TODO: use diff(x) to accomodate non-uniform grid
+    Δx = (model.xmax-model.xmin)./(K-1) # TODO: use diff(x) to accomodate non-uniform grid
     Δτ = model.T/N # TODO: introduce non-uniform timesteps?
 
 
-    vinit = zeros(T1, prod(K+1))
-    for i = 0:K[1]
-        offset = K[2]*i
-        xij = [x[1][i+1], x[2][1]]
-        for j = 1:K[2]+1
-            xij[2] = x[2][j]
-            vinit[offset + j] = model.g(xij)
-        end
+    vinit = zeros(T1, prod(K))
+    for i = 1:K[1], j = 1:K[2]
+        idx = K[2]*(i-1)+j
+        xij = [x[1][i], x[2][j]]
+        vinit[idx] = model.g(xij)
     end
 
     v, pol = timeloopiteration(model, K, N, Δτ, vinit, x, Δx)

--- a/src/solver2d.jl
+++ b/src/solver2d.jl
@@ -1,0 +1,195 @@
+# TODO: better names for the functions
+
+function updatecoeffs!{T<:Real}(coeff0, coeff1f, coeff1b, coeff2f, coeff2b, rhs, model, v, t::T, x,
+                                a1::Vector{T}, a1::Vector{T}, Δτ::T, Δx::Vector{T})
+    # Updates:
+    # rhs    = value function at previous timestep + f at current timestep
+    # coeffn = values in linear system
+    # e.g. coeff0  is the coefficient in front of v at x_{i,j}
+    #      coeff1f is the coefficient in front of v at x_{i+1,j}
+    #      coeff2b is the coefficient in front of v at x_{i,j-1}
+
+
+    # Input
+    # model  = HJBOneDim object
+    # v      = value function at previous timestep
+    # t      = value of (forward) time
+    # x      = vector of x-values
+    # a1     = policy-values on interior, element 1
+    # a2     = policy-values on interior, element 2
+    # Δτ     = time-step size
+    # Δx     = spacial step length
+    taux = Δτ/Δx
+    htaux2 = 0.5*Δτ/Δx^2
+
+    n = length(coeff0)
+    for j = 2:n-1
+        bval = model.b(t,x[j],a[j-1])
+        sval2 = model.σ(t,x[j],a[j-1])^2
+        coeff1[j] = -(sval2*htaux2 + max(bval,0.)*taux)
+        coeff2[j-1] = -(sval2*htaux2 - min(bval,0.)*taux)
+        coeff0[j] = 1.-coeff1[j]-coeff2[j-1]
+        rhs[j] = v[j] + Δτ*model.f(t,x[j],a[j-1])
+    end
+end
+
+function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector)
+    # Loops over each x value and optimises the control
+    # TODO: Should we instead optimize the whole control vector
+    # by considering the sum of the individual objectives
+    # (the gradient should be diagonal?)
+    @assert size(pol1) == size(pol2)
+
+    K = [length(x[1]), length(x[2])]
+    idx = 1.0 ./ Δx
+    hdx2 = 0.5 ./ Δx.^2
+
+    function hamiltonian(a, i::Int, j::Int)
+        # Evaluate Hamiltonian with value a at (t,x_{i,j})
+        linindex = K[2]*(i-1) + j
+        idx1f = linindex + K[2]; idx1b = linindex - K[2]
+        idx2f = linindex + 1;    idx2b = linindex - 1
+
+        xij = [x[1][i], x[2][j]]
+        bval = model.b(t,xij,a)
+        sval2 = model.σ(t,xij,a).^2
+        coeff1f = sval2[1]*hdx2[1] + max(bval[1],0.)*idx[1]
+        coeff1b = sval2[1]*hdx2[1] - min(bval[1],0.)*idx[1]
+        coeff2f = sval2[2]*hdx2[2] + max(bval[2],0.)*idx[2]
+        coeff2b = sval2[2]*hdx2[2] - min(bval[2],0.)*idx[2]
+        coeff0 = -(coeff1f+coeff1b + coeff2f+coeff2b)
+        return (coeff0*v[linindex] + coeff1f*v[idx1f] + coeff1b*v[idx1b] +
+                coeff2f*v[idx2f] + coeff2b*v[idx2b] - model.f(t,xij,a))
+    end
+
+    # TODO: redo pol with same size as v?
+    for i = 1:K[1]-2, j = 1:K[2]-2
+        linidx = K[2]*(i-1) + j
+        objective(a) = hamiltonian(a, i+1, j+1) # i+1,j+1 as the control only lives on the interior
+        g!(x, out) = ForwardDiff.gradient!(out, objective, x)
+        diffobj = DifferentiableFunction(objective, g!)
+        res = optimize(diffobj, [pol1[linidx], pol2[linidx]],
+                       model.amin, model.amax, Fminbox(),
+                       optimizer=LBFGS)
+
+        pol1[linidx], pol2[linidx] = res.minimum
+    end
+end
+
+function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
+                                     v, a1, a2, x::Tuple,
+                                     Δx, Δτ, ti::Int;
+                                     tol = 1e-3,
+                                     scale = 1.0,
+                                     maxpolicyiter::Int = 10)
+    # v  = value function at previous time-step
+    # an = policy function at previous time-step / initial guess for update
+    tol = 1e-3
+    scale = 1.0
+    maxpolicyiter = 10
+    t = model.T - ti*Δτ
+    n = length(v)
+    K = [length(x[1]), length(x[2])]
+    @assert length(a1) == n-2 && length(a2) == n-2
+
+    coeff0 = ones(v)   # v_i
+    coeff1 = zeros(n-1) # v_{i+1} # TODO: type stability
+    coeff2 = zeros(n-1) # v_{i-1} # TODO: type stability
+    rhs = zeros(v)
+    # TODO: add @inbounds
+
+    # Dirichlet conditions for x_2 = {xmin, xmax}
+    for i = 1:K[1]
+        # x_2 = xmin
+        rhs[K[2]*(i-1)+1] = model.Dbound(t, [x[1][i], x[2][1]])
+        # x_2 = xmax
+        rhs[K[2]*i] = model.Dbound(t, [x[1][i], x[2][K[2]]])
+    end
+    # Dirichlet conditions for x_1 = {xmin, xmax}
+    for i = 1:K[2]
+        # x_1 = xmin
+        rhs[i] = model.Dbound(t, [x[1][1], x[2][i]])
+        # x_1 = xmax
+        rhs[K[2]*(K[1]-1)+i] = model.Dbound(t, [x[1][K[1]], x[2][i]])
+    end
+
+    updatecoeffs!(coeff0, coeff1, coeff2, rhs, model, v, t, x, a1, a2, Δτ, Δx)
+    Mat = spdiagm((coeff2, coeff0, coeff1), -1:1, n, n)
+    vnew = Mat\rhs
+
+    pol1 = copy(a1) # TODO: just update a instead?
+    pol2 = copy(a2)
+    updatepol!(pol1, pol2, vnew, model, t, x, Δx)
+
+    for k in 1:maxpolicyiter
+        updatecoeffs!(coeff0, coeff1, coeff2, rhs, model, v, t, x, pol, Δτ, Δx)
+
+        Mat = spdiagm((coeff2, coeff0, coeff1), -1:1, n, n)
+
+        # TODO: Use Krylov solver for high-dimensional PDEs
+        vold = vnew
+        vnew = Mat\rhs
+        updatepol!(pol1, pol2, vnew, model, t, x, Δx)
+
+        vchange = maximum(abs(vnew-vold)./max(1.,abs(vnew)))
+        if vchange < tol
+            break
+        end
+    end
+
+    return vnew, pol1, pol2
+end
+
+function timeloopiteration(model::HJBTwoDimDim, K::Vector{Int}, N::Int,
+                           Δτ, vinit, x, Δx)
+    # Pass v and pol by reference?
+    v = zeros(length(vinit), N+1)
+    # No policy at t = T or at x-boundaries
+    pol1 = zeros(prod(K-1), N)
+    pol2 = zeros(prod(K-1), N)
+    pol = (pol1, pol2)
+
+    @inbounds v[:,1] = vinit # We use forward time t instead of backward time τ
+
+    # initial guess for control
+    pol1init = 0.5*(model.amax[1]-model.amin[1])*ones(prod(K-1))
+    pol2init = 0.5*(model.amax[2]-model.amin[2])*ones(prod(K-1))
+    @inbounds v[:,2], pol1[:,1], pol2[:,1] = policynewtonupdate(model, v[:,1], pol1init, pol2init,
+                                                                x, Δx, Δτ, 1)
+
+    @inbounds for j = 2:N
+        # t = (N-j)*Δτ
+        # TODO: pass v-column, pol-column by reference?
+        @inbounds (v[:,j+1], pol1[:,j],
+                   pol2[:,j]) = policynewtonupdate(model, v[:,j], pol1[:,j-1], pol2[:,j-1],
+                                                   x, Δx, Δτ, j)
+    end
+
+    return v, pol
+end
+
+function solveiteration{T1<:Real}(model::HJBTwoDim{T1}, K::Vector{Int}, N::Int)
+    # K+1 = number of points in each direction of the space domain
+    # N+1 = number of points in time domain
+    x1 = linspace(model.xmin[1], model.xmax[1], K[1]+1)
+    x2 = linspace(model.xmin[2], model.xmax[2], K[2]+1)
+    x = (collect(x1), collect(x2))
+    Δx = (model.xmax-model.xmin)./K # TODO: use diff(x) to accomodate non-uniform grid
+    Δτ = model.T/N # TODO: introduce non-uniform timesteps?
+
+
+    vinit = zeros(T1, prod(K+1))
+    for i = 0:K[1]
+        offset = K[2]*i
+        xij = [x[1][i+1], x[2][1]]
+        for j = 1:K[2]+1
+            xij[2] = x[2][j]
+            vinit[offset + j] = model.g(xij)
+        end
+    end
+
+    v, pol = timeloopiteration(model, K, N, Δτ, vinit, x, Δx)
+    return v, pol
+end
+
+solveiteration(model::HJBTwoDim, K::Int, N::Int) = solveiteration(model, [K,K], N)

--- a/src/solver2d.jl
+++ b/src/solver2d.jl
@@ -1,3 +1,5 @@
+export solve
+
 # TODO: better names for the functions
 
 function setIJV!{T<:Real}(I::Vector{Int},J::Vector{Int},V::Vector{T},
@@ -12,6 +14,7 @@ end
 
 function updatecoeffs!{T<:Real}(I, J, V, rhs, model, v, t::T, x,
                                 a1::Vector{T}, a2::Vector{T}, Δτ::T, Δx::Vector{T})
+    Base.info("Running updatecoeffs")
     # Updates:
     # rhs    = value function at previous timestep + f at current timestep
     # I,J,V  = vectors for creating sparse system matrix (see ?sparse)
@@ -29,11 +32,12 @@ function updatecoeffs!{T<:Real}(I, J, V, rhs, model, v, t::T, x,
     htaux2 = 0.5*Δτ ./ Δx.^2
     K = [length(xi) for xi in x]
 
+    #TODO: add @inbounds
     counter = 0
     # Dirichlet conditions for x_1 = {xmin, xmax}
     for i = [1, K[1]], j = 1:K[2]
         idxi = K[2]*(i-1) + j
-        xij = [x[1][i], x[2][j]])
+        xij = [x[1][i], x[2][j]]
         counter = setIJV!(I,J,V,idxi,idxi,1.0,counter)
         rhs[idxi] = model.Dbound(t, xij)
     end
@@ -41,7 +45,7 @@ function updatecoeffs!{T<:Real}(I, J, V, rhs, model, v, t::T, x,
     # Dirichlet conditions for x_2 = {xmin, xmax}
     for i = 2:K[1]-1, j = [1, K[2]]
         idxi = K[2]*(i-1)+j
-        xij = [x[1][i], x[2][j]])
+        xij = [x[1][i], x[2][j]]
         counter = setIJV!(I,J,V,idxi,idxi,1.0,counter)
         rhs[idxi] = model.Dbound(t, xij)
     end
@@ -75,15 +79,18 @@ function updatecoeffs!{T<:Real}(I, J, V, rhs, model, v, t::T, x,
     @assert counter == length(V)
 end
 
-function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector)
+function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector;
+                    tol=1e-3)
+    Base.info("Running updatepol")
     # Loops over each x value and optimises the control
     # TODO: Should we instead optimize the whole control vector
     # by considering the sum of the individual objectives
     # (the gradient should be diagonal?)
     @assert size(pol1) == size(pol2)
+    #TODO: add @inbounds
 
     K = [length(xi) for xi in x]
-    idx = 1.0 ./ Δx
+    invdx = 1.0 ./ Δx
     hdx2 = 0.5 ./ Δx.^2
 
     function hamiltonian(a, i::Int, j::Int)
@@ -99,26 +106,34 @@ function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector)
         xij = [x[1][i], x[2][j]]
         bval = model.b(t,xij,a)
         sval2 = model.σ(t,xij,a).^2
-        coeff1f = sval2[1]*hdx2[1] + max(bval[1],0.)*idxj[1]
-        coeff1b = sval2[1]*hdx2[1] - min(bval[1],0.)*idxj[1]
-        coeff2f = sval2[2]*hdx2[2] + max(bval[2],0.)*idxj[2]
-        coeff2b = sval2[2]*hdx2[2] - min(bval[2],0.)*idxj[2]
-        return (coeff1f*(v[idxj1f]-v[idxi]) + coeff1b*(v[idxj1b]-v[idxi]) +
-                coeff2f*(v[idxj2f]-v[idxi]) + coeff2b*(v[idxj2b]-v[idxi]) -
+        coeff1f = sval2[1]*hdx2[1] + max(bval[1],0.)*invdx[1]
+        coeff1b = sval2[1]*hdx2[1] - min(bval[1],0.)*invdx[1]
+        coeff2f = sval2[2]*hdx2[2] + max(bval[2],0.)*invdx[2]
+        coeff2b = sval2[2]*hdx2[2] - min(bval[2],0.)*invdx[2]
+        return (coeff1f*(v[idxi]-v[idxj1f]) + coeff1b*(v[idxi]-v[idxj1b]) +
+                coeff2f*(v[idxi]-v[idxj2f]) + coeff2b*(v[idxi]-v[idxj2b]) -
                 model.f(t,xij,a))
     end
 
     # Only find control values at interior
     for i = 2:K[1]-1, j = 2:K[2]-1
         idxi = K[2]*(i-1) + j
+        #@show [t, x[1][i], x[2][j]]
         objective(a) = hamiltonian(a, i, j)
-        g!(x, out) = ForwardDiff.gradient!(out, objective, x)
-        diffobj = DifferentiableFunction(objective, g!)
-        res = optimize(diffobj, [pol1[idxi], pol2[idxi]],
-                       model.amin, model.amax, Fminbox(),
-                       optimizer = LBFGS)
-
+        #g!(x, out) = ForwardDiff.gradient!(out, objective, x)
+        #diffobj = DifferentiableFunction(objective, g!)
+        res = optimize(objective, [pol1[idxi], pol2[idxi]],
+                       NelderMead(), OptimizationOptions(autodiff=true))#f_tol=tol,x_tol=tol,
+                                                    #g_tol=tol,autodiff=true))#,
+#                                                    show_trace=true,
+#                                                    extended_trace=true))#,
+        #model.amin, model.amax, Fminbox(),
+        #optimizer = LBFGS,
+        #optimizer_o = OptimizationOptions(f_tol=tol,x_tol=tol,
+        #g_tol=tol))#,
+        #show_trace=true))
         pol1[idxi], pol2[idxi] = res.minimum
+        #@show
     end
 end
 
@@ -130,9 +145,8 @@ function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
                                      maxpolicyiter::Int = 10)
     # v  = value function at previous time-step
     # an = policy function at previous time-step / initial guess for update
-    tol = 1e-3
-    scale = 1.0
     t = model.T - ti*Δτ
+    @show t
     n = length(v)
     K = [length(xi) for xi in x]
     @assert length(a1) == n && length(a2) == n
@@ -140,21 +154,19 @@ function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
     # Elements in sparse system matrix (n\times n) size
     interiornnz = 5*prod(K-2)
     boundarynnz = 2*(sum(K)-2)
-    totnnz = interioirnnz + boundarynnz
-    I = zeros(totnnz); J = zeros(I); V = zeros(I)
+    totnnz = interiornnz + boundarynnz
+    I = zeros(Int, totnnz); J = zeros(I); V = zeros(T, totnnz)
 
     rhs = zeros(v)
-    # TODO: add @inbounds
 
-    updatecoeffs!(I,J,V, rhs, model, v, t, x, a1, a2, Δτ, Δx)
-    Mat = sparse(I,J,V,n,n,(x,y)->Base.error("Overlap"))
-    vnew = Mat\rhs
-
+    # TODO: copy or pass reference?
     pol1 = copy(a1)
     pol2 = copy(a2)
-    updatepol!(pol1, pol2, vnew, model, t, x, Δx)
+    vnew = copy(v)
 
-    for k in 1:maxpolicyiter
+    for k in 0:maxpolicyiter
+        updatepol!(pol1, pol2, vnew, model, t, x, Δx)
+        #@show reshape(pol1, K[2], K[1])
         updatecoeffs!(I,J,V, rhs, model, v, t, x, pol1, pol2, Δτ, Δx)
 
         Mat = sparse(I,J,V,n,n,(x,y)->Base.error("Overlap"))
@@ -162,13 +174,15 @@ function policynewtonupdate{T<:Real}(model::HJBTwoDim{T},
         # TODO: Use Krylov solver for high-dimensional PDEs?
         vold = vnew
         vnew = Mat\rhs
-        updatepol!(pol1, pol2, vnew, model, t, x, Δx)
 
         vchange = maximum(abs(vnew-vold)./max(1.,abs(vnew)))
-        if vchange < tol
+        @show vchange
+        if vchange < Δτ*tol && k>0
             break
         end
     end
+    # TODO: do we need this one?
+    updatepol!(pol1, pol2, vnew, model, t, x, Δx)
 
     return vnew, pol1, pol2
 end
@@ -178,17 +192,21 @@ function timeloopiteration(model::HJBTwoDim, K::Vector{Int}, N::Int,
     # Pass v and pol by reference?
     v = zeros(length(vinit), N+1)
     # No policy at t = T
-    pol1 = zeros(prod(K), N)
-    pol2 = zeros(prod(K), N)
+    pol1 = zeros(length(vinit), N)
+    pol2 = zeros(length(vinit), N)
     pol = (pol1, pol2)
 
     @inbounds v[:,1] = vinit # We use forward time t instead of backward time τ
 
     # initial guess for control
-    pol1init = 0.5*(model.amax[1]-model.amin[1])*ones(prod(K))
-    pol2init = 0.5*(model.amax[2]-model.amin[2])*ones(prod(K))
+    pol1init = 0.5*(model.amax[1]+model.amin[1])*ones(prod(K))
+    pol2init = 0.5*(model.amax[2]+model.amin[2])*ones(prod(K))
     @inbounds v[:,2], pol1[:,1], pol2[:,1] = policynewtonupdate(model, v[:,1], pol1init, pol2init,
                                                                 x, Δx, Δτ, 1)
+    #@show pol1[:,1]
+    #@show pol2[:,1]
+    #@show v[:,2]
+    #Base.error("Exit")
 
     @inbounds for j = 2:N
         # t = (N-j)*Δτ
@@ -201,7 +219,7 @@ function timeloopiteration(model::HJBTwoDim, K::Vector{Int}, N::Int,
     return v, pol
 end
 
-function solveiteration{T1<:Real}(model::HJBTwoDim{T1}, K::Vector{Int}, N::Int)
+function solve{T1<:Real}(model::HJBTwoDim{T1}, K::Vector{Int}, N::Int)
     # K   = number of points in each direction of the space domain
     # N+1 = number of points in time domain
     x1 = linspace(model.xmin[1], model.xmax[1], K[1])
@@ -209,7 +227,6 @@ function solveiteration{T1<:Real}(model::HJBTwoDim{T1}, K::Vector{Int}, N::Int)
     x = (collect(x1), collect(x2))
     Δx = (model.xmax-model.xmin)./(K-1) # TODO: use diff(x) to accomodate non-uniform grid
     Δτ = model.T/N # TODO: introduce non-uniform timesteps?
-
 
     vinit = zeros(T1, prod(K))
     for i = 1:K[1], j = 1:K[2]
@@ -222,4 +239,4 @@ function solveiteration{T1<:Real}(model::HJBTwoDim{T1}, K::Vector{Int}, N::Int)
     return v, pol
 end
 
-solveiteration(model::HJBTwoDim, K::Int, N::Int) = solveiteration(model, [K,K], N)
+solve(model::HJBTwoDim, K::Int, N::Int) = solve(model, [K,K], N)

--- a/src/solver2d.jl
+++ b/src/solver2d.jl
@@ -129,9 +129,9 @@ function updatepol!(pol1, pol2, v, model::HJBTwoDim, t, x::Tuple, Δx::Vector;
         #diffobj = DifferentiableFunction(objective, g!)
         res = optimize(objective, [pol1[idxi], pol2[idxi]],
                        NelderMead(), OptimizationOptions(autodiff=true))#f_tol=tol,x_tol=tol,
-                                                    #g_tol=tol,autodiff=true))#,
-#                                                    show_trace=true,
-#                                                    extended_trace=true))#,
+        #g_tol=tol,autodiff=true))#,
+        #                                                    show_trace=true,
+        #                                                    extended_trace=true))#,
         #model.amin, model.amax, Fminbox(),
         #optimizer = LBFGS,
         #optimizer_o = OptimizationOptions(f_tol=tol,x_tol=tol,

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-export HJBOneDim
+export HJBOneDim, HJBTwoDim
 
 abstract AbstractHJB
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,3 +17,20 @@ type HJBOneDim{T1<:Real} <: AbstractHJB
     bcond::Tuple{Bool,Bool}
     Dfun::Tuple{Function,Function} # Dirichlet condition on boundaries
 end
+
+
+type HJBTwoDim{T1<:Real} <: AbstractHJB
+    b::Function      # Drift term
+    σ::Function      # Volatility term
+    f::Function      # "Gain" function
+    g::Function      # Terminal value
+    T::T1            # Terminal time
+    amin::Vector{T1} # Control minimum value
+    amax::Vector{T1} # Control maximum value
+    xmin::Vector{T1} # Domain minimum value
+    xmax::Vector{T1} # Domain maximum value
+    Dbound::Function # Dirichlet condition on x-boundary
+    # TODO: assert T>0, amin < amax, xmin < xmax
+    # TODO: assert that the vectors are of size 2
+    # TODO: make sure b and sigma return a length-2 vector
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Base.Test
 
 include("mertontest.jl")
 include("boundarytest.jl")
+include("test2d.jl")
 
 FactCheck.exitstatus()
 end

--- a/test/test2d.jl
+++ b/test/test2d.jl
@@ -16,7 +16,7 @@ function createmodel(;T::Float64=1.)
 
     truesol(t,x) = (t-T)*(x[1]+x[2])^2+vecdot(c,x)
     truepol(t,x) = (1+c+2*(t-T)*(x[1]+x[2]-γ.^2))./(2-2*(t-T)*γ.^2)
-    hatf(t,x) = (x[1]+x[2])^2+sum((1-c-2*(t-T)*(x[1]+x[2])^2)./(4-4*(t-T)*γ.^2))
+    hatf(t,x) = (x[1]+x[2])^2+sum((1-c-2*(t-T)*(x[1]+x[2])).^2./(4-4*(t-T)*γ.^2))
 
     amin = truepol(0., xmax) - 1e-1
     amax = truepol(0., xmin) + 1e-1
@@ -31,8 +31,7 @@ function createmodel(;T::Float64=1.)
 end
 
 
-function calculateerror_iter(prob::TestProblem2D, K::Vector{Int}, N::Int)
-    @time v, pol = solve(prob.model, K, N)
+function calculateerror(prob::TestProblem2D, K::Vector{Int}, v,pol)
     model = prob.model
 
     x1 = linspace(model.xmin[1], model.xmax[1], K[1])
@@ -50,32 +49,40 @@ function calculateerror_iter(prob::TestProblem2D, K::Vector{Int}, N::Int)
 end
 
 facts("2D, Policy iteration") do
-    K = [51, 51]; N = 10
-    prob = createmodel(T=1e-2*N)
-    # TODO: calculate error at two-three different space-time points instead
+    K = [51, 51]; N = 20
+    Δt = 2e-2
+    prob = createmodel(T=Δt*N)
+    model = prob.model
 
-    errv, erra1, erra2 = calculateerror_iter(prob, K, N)
-    @fact errv --> roughly(0., 1e-10)
-    @fact erra1 --> roughly(0., 1e-10)
-    @fact erra2 --> roughly(0., 1e-10)
+    @time v, pol = solve(model, K, N)
+    errv, erra1, erra2 = calculateerror(prob, K, v, pol)
 
+    @fact errv --> roughly(0., 1e-3)
+    @fact erra1 --> roughly(0., 5e-2)
+    @fact erra2 --> roughly(0., 5e-2)
 end
-#     model = prob.model
-#     v, pol = solve(model, K, N)
-#     x1 = linspace(model.xmin[1], model.xmax[1], K[1])
-#     x2 = linspace(model.xmin[2], model.xmax[2], K[2])
-#     x = (collect(x1), collect(x2))
 
-#     i,j = ceil(Int, K/2)
-#     idxi = K[2]*(i-1) + j
-#     xij = [x1[i], x2[j]]
-#     w = prob.truevaluefun(0., xij)
-#     α = prob.truecontrolfun(0., xij)
+facts("2D, Policy timestepping") do
+    K = [51, 51]; N = 10; M = (20,20)
+    Δt = 2e-2
+    prob = createmodel(T=Δt*N)
+    model = prob.model
+
+    avals1 = linspace(model.amin[1], model.amax[1], M[1])
+    avals2 = linspace(model.amin[2], model.amax[2], M[2])
+
+    @time v, pol = solve(model, K, N, (avals1,avals2))
+
+    errv, erra1, erra2 = calculateerror(prob, K, v, pol)
+    @fact errv --> roughly(0., 1e-3)
+    @fact erra1 --> roughly(0., 0.25)
+    @fact erra2 --> roughly(0., 0.25)
+end
 
 
-# end
+#==
 
-function calctruesols(t, x, prob)
+function calctruesols(t, x, prob, flat=false)
     K = [length(xi) for xi in x]
     v = zeros(reverse(K)...)
     pol1 = zeros(v)
@@ -86,125 +93,30 @@ function calctruesols(t, x, prob)
         v[j,i] = prob.truevaluefun(t, xij)
         pol1[j,i], pol2[j,i] = prob.truecontrolfun(t, xij)
     end
+    if flat == true
+        v = v[:]
+        pol1 = pol1[:]
+        pol2 = pol2[:]
+    end
     return v, (pol1, pol2)
 end
 
-#facts("2D, Policy timestepping") do
-K = [26, 26]; N = 4
-prob = createmodel(T=1e-2*N)
+K = [51, 51]; N = 50
+Δt = 2e-2
+prob = createmodel(T=Δt*N)
 model = prob.model
-M = [81, 81]
-avals1 = linspace(model.amin[1], model.amax[1], M[1])
-avals2 = linspace(model.amin[2], model.amax[2], M[2])
-
-
-
-# TODO: calculate error at two-three different space-time points instead
-v, pol = solve(prob.model, K, N, (avals1,avals2))
-#errv, erra1, erra2 = calculateerror_iter(prob, K, N)
-
 x1 = linspace(model.xmin[1], model.xmax[1], K[1])
 x2 = linspace(model.xmin[2], model.xmax[2], K[2])
 x = (collect(x1), collect(x2))
+v, pol = solve(prob.model, K, N)
 
-i,j = ceil(Int, K/2)
-idxi = K[2]*(i-1) + j
-xij = [x1[i], x2[j]]
-w = prob.truevaluefun(0., xij)
-α = prob.truecontrolfun(0., xij)
-errv, erra1, erra2 =  (abs(w-v[idxi,1])/abs(w), abs(α[1]-pol[1][idxi,1])/abs(α[1]),
-                       abs(α[2]-pol[2][idxi,1])/abs(α[2]))
-
-
-#@fact errv --> roughly(0., 1e-10)
-#@fact erra1 --> roughly(0., 1e-10)
-#@fact erra2 --> roughly(0., 1e-10)
-#end
-
-
-function testcoeffs{T<:Real}(I, J, V, x, Δτ::T, Δx::Vector{T})
-    Base.info("Running updatecoeffs test")
-
-    taux = Δτ ./Δx
-    htaux2 = 0.5*Δτ ./ Δx.^2
-    K = [length(xi) for xi in x]
-
-    counter = 0
-    # Dirichlet conditions for x_1 = {xmin, xmax}
-    for i = [1, K[1]], j = 1:K[2]
-        idxi = K[2]*(i-1) + j
-        xij = [x[1][i], x[2][j]]
-        counter = setIJV!(I,J,V,idxi,idxi,1.0,counter)
-        #rhs[idxi] = model.Dbound(t, xij)
-    end
-
-    # Dirichlet conditions for x_2 = {xmin, xmax}
-    for i = 2:K[1]-1, j = [1, K[2]]
-        idxi = K[2]*(i-1)+j
-        xij = [x[1][i], x[2][j]]
-        counter = setIJV!(I,J,V,idxi,idxi,1.0,counter)
-        #        rhs[idxi] = model.Dbound(t, xij)
-    end
-
-    # Interior coefficients
-    for i = 2:K[1]-1, j = 2:K[2]-1
-        idxi = K[2]*(i-1) + j
-        idxj1f = idxi + K[2]; idxj1b = idxi - K[2]
-        idxj2f = idxi + 1;    idxj2b = idxi - 1
-        xij = [x[1][i], x[2][j]]
-        #aij = [a1[idxi], a2[idxi]]
-
-        #bval = model.b(t,xij,aij)
-        #sval2 = model.σ(t,xij,aij).^2
-        coeff1f = -(htaux2[1] + max(-1,0.)*taux[1])
-        coeff1b = -(htaux2[1] - min(-1,0.)*taux[1])
-        coeff2f = -(htaux2[2] + max(-1,0.)*taux[2])
-        coeff2b = -(htaux2[2] - min(-1,0.)*taux[2])
-        coeff0 = 1.0-(coeff1f+coeff1b + coeff2f+coeff2b)
-
-        # TODO: does it make a performance difference what order I put these in?
-        counter = setIJV!(I,J,V,idxi,idxi,coeff0, counter)
-        counter = setIJV!(I,J,V,idxi,idxj1f,coeff1f, counter)
-        counter = setIJV!(I,J,V,idxi,idxj1b,coeff1b, counter)
-        counter = setIJV!(I,J,V,idxi,idxj2f,coeff2f, counter)
-        counter = setIJV!(I,J,V,idxi,idxj2b,coeff2b, counter)
-
-        #rhs[idxi] = v[idxi] + Δτ*model.f(t,xij,aij)
-    end
-
-    @assert counter == length(V)
+tv = zeros(v)
+tpol1 = zeros(pol[1])
+tpol2 = zeros(pol[2])
+for i = 1:N
+tv[:,i], tmppol = calctruesols((i-1)*Δt, x, prob, true)
+tpol1[:,i] = tmppol[1]
+tpol2[:,i] = tmppol[2]
 end
-
-
-function main()
-    prob = createmodel()
-    model = prob.model
-    K = [101,101]
-    N = 51
-    x1 = linspace(model.xmin[1], model.xmax[1], K[1])
-    x2 = linspace(model.xmin[2], model.xmax[2], K[2])
-    x = (collect(x1), collect(x2))
-    Δx = (model.xmax-model.xmin)./(K-1)
-    Δτ = model.T/N
-    @show Δx, x1[2]-x1[1], x2[2]-x2[1]
-
-    vinit = zeros(prod(K))
-    for i = 1:K[1], j = 1:K[2]
-        idx = K[2]*(i-1)+j
-        xij = [x[1][i], x[2][j]]
-        vinit[idx] = model.g(xij)
-    end
-    n = length(vinit)
-
-    # Elements in sparse system matrix (n\times n) size
-    interiornnz = 5*prod(K-2)
-    boundarynnz = 2*(sum(K)-2)
-    totnnz = interiornnz + boundarynnz
-    I = zeros(Int, totnnz); J = zeros(I); V = zeros(totnnz)
-    testcoeffs(I,J,V, x, Δτ, Δx)
-    Mat = sparse(I,J,V,n,n,(x,y)->Base.error("Overlap"))
-    return Mat
-end
-#using PyPlot
-#Mat = main()
-#spy(Mat)
+tv[:,end], tmppol = calctruesols(model.T,x,prob, true)
+==#

--- a/test/test2d.jl
+++ b/test/test2d.jl
@@ -49,28 +49,31 @@ function calculateerror_iter(prob::TestProblem2D, K::Vector{Int}, N::Int)
     abs(α[2]-pol[2][idxi,end])/abs(α[2])
 end
 
-#facts("2D, Policy iteration") do
-# K = [201, 101]; N = 3
-# prob = createmodel(T=1e-3*N)
-# # TODO: calculate error at two-three different space-time points instead
-# v, pol = solve(prob.model, K, N)
-# #errv, erra1, erra2 = calculateerror_iter(prob, K, N)
-# model = prob.model
+facts("2D, Policy iteration") do
+    K = [51, 51]; N = 10
+    prob = createmodel(T=1e-2*N)
+    # TODO: calculate error at two-three different space-time points instead
 
-# x1 = linspace(model.xmin[1], model.xmax[1], K[1])
-# x2 = linspace(model.xmin[2], model.xmax[2], K[2])
-# x = (collect(x1), collect(x2))
+    errv, erra1, erra2 = calculateerror_iter(prob, K, N)
+    @fact errv --> roughly(0., 1e-10)
+    @fact erra1 --> roughly(0., 1e-10)
+    @fact erra2 --> roughly(0., 1e-10)
 
-# i,j = ceil(Int, K/2)
-# idxi = K[2]*(i-1) + j
-# xij = [x1[i], x2[j]]
-# w = prob.truevaluefun(0., xij)
-# α = prob.truecontrolfun(0., xij)
+end
+#     model = prob.model
+#     v, pol = solve(model, K, N)
+#     x1 = linspace(model.xmin[1], model.xmax[1], K[1])
+#     x2 = linspace(model.xmin[2], model.xmax[2], K[2])
+#     x = (collect(x1), collect(x2))
 
-# @fact errv --> roughly(0., 1e-10)
-# @fact erra1 --> roughly(0., 1e-10)
-# @fact erra2 --> roughly(0., 1e-10)
-# #end
+#     i,j = ceil(Int, K/2)
+#     idxi = K[2]*(i-1) + j
+#     xij = [x1[i], x2[j]]
+#     w = prob.truevaluefun(0., xij)
+#     α = prob.truecontrolfun(0., xij)
+
+
+# end
 
 function calctruesols(t, x, prob)
     K = [length(xi) for xi in x]

--- a/test/test2d.jl
+++ b/test/test2d.jl
@@ -33,6 +33,7 @@ function calculateerror_iter(prob::TestProblem2D, K::Int, N::Int)
     Base.error("Implement this function")
     # TODO: calculate error at time T
     # TODO: return relative norm
+    # TODO: remember that policy is now on the whole domain
 
     # @time v, pol = solve(prob.model, K, N)
     # model = prob.model

--- a/test/test2d.jl
+++ b/test/test2d.jl
@@ -1,0 +1,57 @@
+using HJBSolver, FactCheck
+
+type TestProblem2D{T<:Real}
+    gamma::Vector{T}
+    c::Vector{T}
+    model::HJBTwoDim{T}
+    truevaluefun::Function
+    truecontrolfun::Function
+end
+
+function createmodel()
+    T = 2.
+    γ = [5e-2, 0.1]
+    c = [-1., -0.9]
+
+    xmin = zeros(2); xmax = 3.*ones(2)
+    amin = zeros(2); amax = ones(2)
+
+    truesol(t,x) = (t-T)*(x[1]+x[2])^2+vecdot(c,x)
+    truepol(t,x) = (1+c+2*(t-T)*(x[1]+x[2]-γ.^2))./(2-2*(t-T)γ.^2)
+    hatf(t,x) = (x[1]+x[2])^2+sum((1-c-2*(t-T)*(x[1]+x[2])^2)./(4-4*(t-T)*γ.^2))
+
+    b(t,x,a) = a-1.
+    σ(t,x,a) = (γ.*b(t,x,a)).^2
+    f(t,x,a) = -vecdot(a,b(t,x,a)) - hatf(t,x)
+    g(x) = truesol(T,x)
+
+    model = HJBTwoDim(b, σ, f, g, T, amin, amax, xmin, xmax, truesol)
+    return TestProblem2D(γ, c, model, truesol, truepol)
+end
+
+function calculateerror_iter(prob::TestProblem2D, K::Int, N::Int)
+    Base.error("Implement this function")
+    # TODO: calculate error at time T
+    # TODO: return relative norm
+
+    # @time v, pol = solve(prob.model, K, N)
+    # model = prob.model
+
+    # x = linspace(model.xmin, model.xmax, K+1)
+    # Δτ = model.T/N
+
+    # w = prob.truevaluefun(0., x)
+    # α = prob.truecontrolfun(0., x[2:end-1])
+
+    # return norm(w-v[:,end])/norm(w), norm(α-pol[:,end])/norm(α)
+end
+
+facts("2D, Policy iteration") do
+    K = 2^8; N = 2^7
+    prob = createmodel()
+    # TODO: calculate error at two-three different space-time points instead
+    errv, erra = calculateerror_iter(prob, K, N)
+
+    @fact errv --> roughly(0., 1e-3)
+    @fact erra --> roughly(0., 1e-2)
+end

--- a/test/test2d.jl
+++ b/test/test2d.jl
@@ -45,8 +45,8 @@ function calculateerror_iter(prob::TestProblem2D, K::Vector{Int}, N::Int)
     w = prob.truevaluefun(0., xij)
     α = prob.truecontrolfun(0., xij)
 
-    return abs(w-v[idxi,end])/abs(w), abs(α[1]-pol[1][idxi,end])/abs(α[1]),
-    abs(α[2]-pol[2][idxi,end])/abs(α[2])
+    return abs(w-v[idxi,1])/abs(w), abs(α[1]-pol[1][idxi,1])/abs(α[1]),
+    abs(α[2]-pol[2][idxi,1])/abs(α[2])
 end
 
 facts("2D, Policy iteration") do
@@ -112,10 +112,13 @@ idxi = K[2]*(i-1) + j
 xij = [x1[i], x2[j]]
 w = prob.truevaluefun(0., xij)
 α = prob.truecontrolfun(0., xij)
+errv, erra1, erra2 =  (abs(w-v[idxi,1])/abs(w), abs(α[1]-pol[1][idxi,1])/abs(α[1]),
+                       abs(α[2]-pol[2][idxi,1])/abs(α[2]))
 
-@fact errv --> roughly(0., 1e-10)
-@fact erra1 --> roughly(0., 1e-10)
-@fact erra2 --> roughly(0., 1e-10)
+
+#@fact errv --> roughly(0., 1e-10)
+#@fact erra1 --> roughly(0., 1e-10)
+#@fact erra2 --> roughly(0., 1e-10)
 #end
 
 


### PR DESCRIPTION
Supports problems with 2D state-space and control-space. Only diagonal volatility matrices.
Move towards #3 

The policy-iteration approach is best here for large control-spaces.
